### PR TITLE
Upgrade php-parser and allow 5.8 support

### DIFF
--- a/bin/dredd-hooks-laravel
+++ b/bin/dredd-hooks-laravel
@@ -32,7 +32,7 @@ if (!$loaded) {
 
 // Laravel will not overwrite existing environment variables, so we'll pull in custom ones here
 if (file_exists($basePath . '/.env.dredd')) {
-    $dotenv = new Dotenv\Dotenv($basePath, '.env.dredd');
+    $dotenv = new Dotenv\Dotenv(new \Dotenv\Loader([$basePath . '/.env.dredd'], new \Dotenv\Environment\DotenvFactory()));
     $dotenv->overload();
 }
 

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "package",
     "require": {
         "php": ">=7.1",
-        "nikic/php-parser": "^3.1",
+        "nikic/php-parser": "^4.2",
         "ddelnano/dredd-hooks-php": "^1.1"
     },
     "license": "MIT",

--- a/server.php
+++ b/server.php
@@ -7,7 +7,7 @@ require $basePath . '/vendor/autoload.php';
 
 // Laravel will not overwrite existing environment variables, so we'll pull in custom ones here
 if (file_exists($basePath . '/.env.dredd')) {
-    $dotenv = new Dotenv\Dotenv($basePath, '.env.dredd');
+    $dotenv = new Dotenv\Dotenv(new \Dotenv\Loader([$basePath . '/.env.dredd'], new \Dotenv\Environment\DotenvFactory()));
     $dotenv->overload();
 }
 


### PR DESCRIPTION
I've added support for laravel 5.8 (Breaking non-bc change due to DotEnv package)

There are no tests - so I can't add any tests for this, but yeah let me know what you think and thanks for the original package! 👍 